### PR TITLE
Fix /richie-editions-redirect/ urls when wordpress is inside a subfolder

### DIFF
--- a/includes/class-richie-editions-issue.php
+++ b/includes/class-richie-editions-issue.php
@@ -91,6 +91,6 @@ class Richie_Editions_Issue {
      * @return url
      */
     public function get_redirect_url() {
-        return get_site_url( null, '/richie-editions-redirect/' . $this->product . '/' . $this->uuid, 'relative' );
+        return get_home_url( null, '/richie-editions-redirect/' . $this->product . '/' . $this->uuid, 'relative' );
     }
 }


### PR DESCRIPTION
[`get_site_url()`](https://developer.wordpress.org/reference/functions/get_site_url/) is used to get access to the path where WordPress application files are (which can be in a subfolder).